### PR TITLE
⚡ Optimize KrushemMarker re-renders

### DIFF
--- a/src/components/krushem-marker.tsx
+++ b/src/components/krushem-marker.tsx
@@ -25,6 +25,18 @@ function KrushemMarker({ restaurant, radius, now }: Props) {
     []
   );
 
+  const popup = useMemo(
+    () => (
+      <RestaurantPopup
+        restaurant={restaurant}
+        now={now}
+        isPopupOpen={isPopupOpen}
+      />
+    ),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [restaurant, isPopupOpen, isPopupOpen ? now : null]
+  );
+
   return (
     <CircleMarker
       center={[restaurant.coords.latitude, restaurant.coords.longitude]}
@@ -34,11 +46,7 @@ function KrushemMarker({ restaurant, radius, now }: Props) {
       stroke={false}
       eventHandlers={eventHandlers}
     >
-      <RestaurantPopup
-        restaurant={restaurant}
-        now={now}
-        isPopupOpen={isPopupOpen}
-      />
+      {popup}
     </CircleMarker>
   );
 }


### PR DESCRIPTION
Optimized `KrushemMarker` to prevent unnecessary re-renders of the map marker when the global time (`now`) updates. 

*   **What:** Implemented `useMemo` for the `RestaurantPopup` child element inside `KrushemMarker`.
*   **Why:** Even though `RestaurantPopup` is memoized, the `KrushemMarker` component was re-creating the JSX element on every render (triggered by `now` updates from the parent). This caused the `CircleMarker` to perceive a children update.
*   **How:** The `useMemo` hook uses a conditional dependency `isPopupOpen ? now : null`. This means when the popup is closed, changes to `now` do not invalidate the memoized `popup` element, keeping the reference stable and avoiding re-renders of the underlying Leaflet marker. When the popup is open, it updates normally.


---
*PR created automatically by Jules for task [11822095767378837356](https://jules.google.com/task/11822095767378837356) started by @metacurb*